### PR TITLE
#11: Included javax.activation into dependencies

### DIFF
--- a/poetryclub-db/pom.xml
+++ b/poetryclub-db/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>poetryclub-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
                 <version>20180130</version>
             </dependency>
             <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>activation</artifactId>
+                <version>1.1.1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jooq</groupId>
                 <artifactId>jooq</artifactId>
                 <version>3.11.3</version>


### PR DESCRIPTION
Closes #11. Explicitly included `javax.activation` into dependencies.